### PR TITLE
Add SolanaJ and Solnet libraries to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Please submit a pull request if you know any resources that might be helpful to 
 - [Run a Solana Validator Cluster](https://github.com/project-serum/validators)
 - [Solana Go](https://github.com/dfuse-io/solana-go)
 - [Solana Python](https://github.com/michaelhly/solana-py)
+- [SolanaJ (Java)](https://github.com/skynetcapital/solanaj)
+- [Solnet (C#/.NET)](https://github.com/bmresearch/Solnet)
 - [Progamming on Solana - An introduction](https://paulx.dev/2021/01/14/programming-on-solana-an-introduction/)
 - [Solana Framework](https://github.com/project-serum/anchor)
 


### PR DESCRIPTION
Adds the following Solana/Serum programming libraries to the readme:
- [SolanaJ (Java)](https://github.com/skynetcapital/solanaj)
- [Solnet (C#/.NET)](https://github.com/bmresearch/Solnet)