### PR TITLE
Add Star Atlas Marketplace to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Most of these projects are not open source. Use at your own risk.
 
 - [Solible](https://solible.com)
 
+#### Video Games
+- [Star Atlas Marketplace](https://play.staratlas.com/market)
+
 ### Wallets
 
 #### Web


### PR DESCRIPTION
Adding a link to the Star Atlas Marketplace on the README.  The Star Atlas Marketplace is built using Serum for their exchange.

See: https://play.staratlas.com/market

:)